### PR TITLE
Update index.html and config.yml to display LibTask information in index.html instead of ab3

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -8,7 +8,7 @@ header_pages:
 
 markdown: kramdown
 
-repository: "se-edu/addressbook-level3"
+repository: "AY2122S2-CS2103T-W14-1/tp"
 github_icon: "images/github-icon.png"
 
 plugins:

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,17 +1,17 @@
 ---
 layout: page
-title: AddressBook Level-3
+title: LibTask
 ---
 
-[![CI Status](https://github.com/se-edu/addressbook-level3/workflows/Java%20CI/badge.svg)](https://github.com/se-edu/addressbook-level3/actions)
+[![CI Status](https://github.com/AY2122S2-CS2103T-W14-1/tp/workflows/Java%20CI/badge.svg)](https://github.com/AY2122S2-CS2103T-W14-1/tp/actions)
 [![codecov](https://codecov.io/gh/AY2122S2-CS2103T-W14-1/tp/branch/master/graph/badge.svg?token=XNUDJ0U08U)](https://codecov.io/gh/AY2122S2-CS2103T-W14-1/tp)
 
 ![Ui](images/Ui.png)
 
-**AddressBook is a desktop application for managing your contact details.** While it has a GUI, most of the user interactions happen using a CLI (Command Line Interface).
+**LibTask** is a desktop application to allow librarians to keep track of book statuses and contact details of patrons who have borrowed them or requested for them. While it has a GUI, most of the user interactions happen using a CLI (Command Line Interface).
 
-* If you are interested in using AddressBook, head over to the [_Quick Start_ section of the **User Guide**](UserGuide.html#quick-start).
-* If you are interested about developing AddressBook, the [**Developer Guide**](DeveloperGuide.html) is a good place to start.
+* If you are interested in using LibTask, head over to the [_Quick Start_ section of the **User Guide**](UserGuide.html#quick-start).
+* If you are interested about developing LibTask, the [**Developer Guide**](DeveloperGuide.html) is a good place to start.
 
 
 **Acknowledgements**


### PR DESCRIPTION
Currently, our site [main page](https://ay2122s2-cs2103t-w14-1.github.io/tp/) is still reflecting the old AB3 and this PR will update index.html and _config.yml with the relevant links and information to reflect LibTask.
