### PR TITLE
Command: Made first step to refactor into packages

### DIFF
--- a/src/main/java/seedu/address/logic/commands/Command.java
+++ b/src/main/java/seedu/address/logic/commands/Command.java
@@ -8,6 +8,18 @@ import seedu.address.model.Model;
  */
 public abstract class Command {
 
+    public static final String PATRON_COMMAND_GROUP = "patron";
+    public static final String BOOK_COMMAND_GROUP = "book";
+
+    public static final String ADD_COMMAND_WORD = "add";
+    public static final String EDIT_COMMAND_WORD = "add";
+    public static final String DELETE_COMMAND_WORD = "delete";
+    public static final String FIND_COMMAND_WORD = "find";
+    public static final String LIST_COMMAND_WORD = "list";
+    public static final String HELP_COMMAND_WORD = "help";
+    public static final String EXIT_COMMAND_WORD = "exit";
+    public static final String CLEAR_COMMAND_WORD = "clear";
+
     /**
      * Executes the command and returns the result message.
      *

--- a/src/main/java/seedu/address/logic/commands/book/AddBookCommand.java
+++ b/src/main/java/seedu/address/logic/commands/book/AddBookCommand.java
@@ -1,0 +1,46 @@
+package seedu.address.logic.commands.book;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.book.Book;
+
+/**
+ * Adds a book to the address book.
+ */
+public class AddBookCommand extends Command {
+
+    // TODO : Improve messages
+    public static final String MESSAGE_USAGE = PATRON_COMMAND_GROUP + " " + ADD_COMMAND_WORD
+            + ": Adds a book to LibTask. ";
+
+    public static final String MESSAGE_SUCCESS = "New book added: %1$s";
+
+    private final Book toAdd;
+
+    /**
+     * Creates an AddBookCommand to add the specified {@code Book}
+     */
+    public AddBookCommand(Book book) {
+        requireNonNull(book);
+        toAdd = book;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
+        model.addBook(toAdd);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof AddBookCommand // instanceof handles nulls
+                && toAdd.equals(((AddBookCommand) other).toAdd));
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/book/DeleteBookCommand.java
+++ b/src/main/java/seedu/address/logic/commands/book/DeleteBookCommand.java
@@ -1,0 +1,56 @@
+package seedu.address.logic.commands.book;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.book.Book;
+
+/**
+ * Deletes a book identified using it's displayed index from LibTask.
+ */
+public class DeleteBookCommand extends Command {
+
+    // TODO : Improve messages
+    public static final String MESSAGE_USAGE = PATRON_COMMAND_GROUP + " " + DELETE_COMMAND_WORD
+            + ": Deletes the book identified by the index number used in the displayed book list.\n"
+            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Example: " + PATRON_COMMAND_GROUP + " " + DELETE_COMMAND_WORD + " 1";
+
+    public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person: %1$s";
+
+    private final Index targetIndex;
+
+    public DeleteBookCommand(Index targetIndex) {
+        this.targetIndex = targetIndex;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Book> lastShownList = model.getFilteredBookList();
+
+        if (targetIndex.getZeroBased() >= lastShownList.size()) {
+            // TODO : Change this message
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        Book bookToDelete = lastShownList.get(targetIndex.getZeroBased());
+        model.deleteBook(bookToDelete);
+        // TODO : Change this message
+        return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, bookToDelete));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof DeleteBookCommand // instanceof handles nulls
+                && targetIndex.equals(((DeleteBookCommand) other).targetIndex)); // state check
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -2,6 +2,9 @@ package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.logic.commands.Command.CLEAR_COMMAND_WORD;
+import static seedu.address.logic.commands.Command.EXIT_COMMAND_WORD;
+import static seedu.address.logic.commands.Command.HELP_COMMAND_WORD;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -15,6 +18,7 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.parser.book.BookCommandParser;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -44,28 +48,41 @@ public class AddressBookParser {
         final String arguments = matcher.group("arguments");
         switch (commandWord) {
 
+        case Command.PATRON_COMMAND_GROUP:
+            // TODO : ADITI please do something like "return new PatronCommandParser().parse(arguments);"
+            return null;
+
+        case Command.BOOK_COMMAND_GROUP:
+            return new BookCommandParser().parse(arguments);
+
+        // TODO : ADITI please move add, edit, del, find, list into your new PatronCommandParser class in new package
+        // TODO : CHANGE TO "case ADD_COMMAND_WORD", import static "ADD_COMMAND_WORD" from Command class
         case AddCommand.COMMAND_WORD:
             return new AddCommandParser().parse(arguments);
 
+        // TODO : CHANGE TO "case EDIT_COMMAND_WORD", import static "EDIT_COMMAND_WORD" from Command class
         case EditCommand.COMMAND_WORD:
             return new EditCommandParser().parse(arguments);
 
+        // TODO : CHANGE TO "case DELETE_COMMAND_WORD", import static "DELETE_COMMAND_WORD" from Command class
         case DeleteCommand.COMMAND_WORD:
             return new DeleteCommandParser().parse(arguments);
 
-        case ClearCommand.COMMAND_WORD:
-            return new ClearCommand();
-
+        // TODO : CHANGE TO "case FIND_COMMAND_WORD", import static "FIND_COMMAND_WORD" from Command class
         case FindCommand.COMMAND_WORD:
             return new FindCommandParser().parse(arguments);
 
+        // TODO : CHANGE TO "case LIST_COMMAND_WORD", import static "LIST_COMMAND_WORD" from Command class
         case ListCommand.COMMAND_WORD:
             return new ListCommand();
 
-        case ExitCommand.COMMAND_WORD:
+        case CLEAR_COMMAND_WORD:
+            return new ClearCommand();
+
+        case EXIT_COMMAND_WORD:
             return new ExitCommand();
 
-        case HelpCommand.COMMAND_WORD:
+        case HELP_COMMAND_WORD:
             return new HelpCommand();
 
         default:

--- a/src/main/java/seedu/address/logic/parser/book/AddBookCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/book/AddBookCommandParser.java
@@ -1,0 +1,35 @@
+package seedu.address.logic.parser.book;
+
+import java.util.stream.Stream;
+
+import seedu.address.logic.commands.book.AddBookCommand;
+import seedu.address.logic.parser.ArgumentMultimap;
+import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.Prefix;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new AddBookCommand object
+ */
+public class AddBookCommandParser implements Parser<AddBookCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the AddBookCommand
+     * and returns an AddBookCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public AddBookCommand parse(String args) throws ParseException {
+
+        // TODO : Implement parse function
+
+        return null;
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/book/BookCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/book/BookCommandParser.java
@@ -1,0 +1,56 @@
+package seedu.address.logic.parser.book;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.HelpCommand;
+import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses user input that is already processed by AddressBookParser into a Command object
+ *
+ * @see seedu.address.logic.parser.AddressBookParser
+ */
+public class BookCommandParser implements Parser<Command> {
+
+    /**
+     * Used for initial separation of command word and args.
+     */
+    private static final Pattern BASIC_COMMAND_FORMAT = Pattern.compile("(?<commandWord>\\S+)(?<arguments>.*)");
+
+    /**
+     * Parses user input into command for execution.
+     *
+     * @param userInput user input string that is alaready processed by {@code AddressBookParser}
+     * @return the command based on the user input
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public Command parse(String userInput) throws ParseException {
+        final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
+        if (!matcher.matches()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
+        }
+
+        final String commandWord = matcher.group("commandWord");
+        final String arguments = matcher.group("arguments");
+
+        switch (commandWord) {
+
+        case Command.ADD_COMMAND_WORD:
+            return new AddBookCommandParser().parse(arguments);
+
+        case Command.DELETE_COMMAND_WORD:
+            return new DeleteBookCommandParser().parse(arguments);
+
+        // TODO : Add cases for Edit, List and Find
+
+        default:
+            throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
+        }
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/book/DeleteBookCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/book/DeleteBookCommandParser.java
@@ -1,0 +1,35 @@
+package seedu.address.logic.parser.book;
+
+import java.util.stream.Stream;
+
+import seedu.address.logic.commands.book.DeleteBookCommand;
+import seedu.address.logic.parser.ArgumentMultimap;
+import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.Prefix;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new DeleteBookCommand object
+ */
+public class DeleteBookCommandParser implements Parser<DeleteBookCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the DeleteBookCommand
+     * and returns an DeleteBookCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public DeleteBookCommand parse(String args) throws ParseException {
+
+        // TODO : Implement parse function
+
+        return null;
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+}


### PR DESCRIPTION
Our current parser does not support the parsing of commands with
2-word command words such as "patron add" or "book edit"

Let's:
* Add a layer of abstraction (i.e. BookCommandParser and
PatronCommandParser) so that parseCommand() from the original top-level
parser can call the parser() functions in these newly created classes
* Package all patron related commands into patron package, and book
related edit, delete, find, list, add commands into book package
* Package the same way for patron command parsers and book command
parsers
* Remove "COMMAND_WORD" from individual command classes, and refactor
them as a public static variable in Command class

Refactoring "COMMAND_WORD" is needed as some of the command words are
the same for different groups of commands (e.g. patron and book commands
). Refactoring eases the import, and reduces the chances of having
inconsistencies. It is also easier to change in the future, if needed.

The layer of abstraction and packaging is also needed so that we apply
SLAP principals, and avoid having long method for parseCommand()
function.