### PR TITLE
Create request command and fix data integrity issues

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -16,4 +16,6 @@ public class Messages {
     public static final String MESSAGE_NO_BOOKS_BORROWED = "Patron %1$s did not borrow any book!";
     public static final String MESSAGE_BOOK_ALREADY_BORROWED = "%1$s is already borrowed!";
     public static final String MESSAGE_RETURN_DATE_TOO_EARLY = "Return date must be later than today's date!";
+    public static final String MESSAGE_SAME_ISBN_INCONSISTENT = "There already exists a book with isbn %1$s, "
+            + "but has different authors or name!\n";
 }

--- a/src/main/java/seedu/address/logic/commands/ReturnAllBooksCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ReturnAllBooksCommand.java
@@ -9,6 +9,7 @@ import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.book.Book;
 import seedu.address.model.patron.Patron;
 
 /**
@@ -16,7 +17,7 @@ import seedu.address.model.patron.Patron;
  */
 public class ReturnAllBooksCommand extends ReturnCommand {
 
-    public static final String MESSAGE_SUCCESS = "Returned all books borrowed by: %1$s";
+    public static final String MESSAGE_SUCCESS = "Returned all books borrowed by: %1$s\n";
 
     private final Index patronIndex;
 
@@ -39,10 +40,11 @@ public class ReturnAllBooksCommand extends ReturnCommand {
         if (!model.isBorrowingSomeBook(borrower)) {
             throw new CommandException(String.format(Messages.MESSAGE_NO_BOOKS_BORROWED, borrower.getName()));
         }
-        model.returnAllBorrowedBooks(borrower);
+        List<Book> returnedBooks = model.returnAllBorrowedBooks(borrower);
+        String notification = model.deleteAllRequests(returnedBooks.toArray(Book[]::new));
 
         model.updateFilteredBookList(PREDICATE_SHOW_ALL_BOOKS);
-        return new CommandResult(String.format(MESSAGE_SUCCESS, borrower.getName()));
+        return new CommandResult(String.format(MESSAGE_SUCCESS, borrower.getName()) + notification);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/ReturnOneBookCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ReturnOneBookCommand.java
@@ -17,7 +17,7 @@ import seedu.address.model.book.BookStatus;
  */
 public class ReturnOneBookCommand extends ReturnCommand {
 
-    public static final String MESSAGE_SUCCESS = "Returned book: %1$s";
+    public static final String MESSAGE_SUCCESS = "Returned book: %1$s\n";
 
     private final Index bookIndex;
 
@@ -43,9 +43,9 @@ public class ReturnOneBookCommand extends ReturnCommand {
         }
         Book updatedAvailableBook = new Book(bookToReturn, BookStatus.createAvailableBookStatus());
         model.setBook(bookToReturn, updatedAvailableBook);
-
+        String notification = model.deleteAllRequests(bookToReturn);
         model.updateFilteredBookList(PREDICATE_SHOW_ALL_BOOKS);
-        return new CommandResult(String.format(MESSAGE_SUCCESS, bookToReturn.getBookName()));
+        return new CommandResult(String.format(MESSAGE_SUCCESS, bookToReturn.getBookName()) + notification);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/book/AddBookCommand.java
+++ b/src/main/java/seedu/address/logic/commands/book/AddBookCommand.java
@@ -6,6 +6,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_ISBN;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
+import seedu.address.commons.core.Messages;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -32,8 +33,6 @@ public class AddBookCommand extends Command {
             + PREFIX_TAG + "Magic";
 
     public static final String MESSAGE_SUCCESS = "New book added: %1$s.\n";
-    public static final String MESSAGE_SAME_ISBN_INCONSISTENT = "There already exists a book with isbn %1$s, "
-            + "but has different authors or name!\n";
 
     private final Book toAdd;
 
@@ -49,7 +48,7 @@ public class AddBookCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         if (model.hasSameIsbnDiffAuthorsOrName(toAdd)) {
-            throw new CommandException(String.format(MESSAGE_SAME_ISBN_INCONSISTENT, toAdd.getIsbn()));
+            throw new CommandException(String.format(Messages.MESSAGE_SAME_ISBN_INCONSISTENT, toAdd.getIsbn()));
         }
         // Remove all requests for this isbn and notify all requesters who requested for a book with toAdd's isbn
         String notification = model.deleteAllRequests(toAdd);

--- a/src/main/java/seedu/address/logic/commands/book/AddBookCommand.java
+++ b/src/main/java/seedu/address/logic/commands/book/AddBookCommand.java
@@ -31,7 +31,9 @@ public class AddBookCommand extends Command {
             + PREFIX_TAG + "Adventure "
             + PREFIX_TAG + "Magic";
 
-    public static final String MESSAGE_SUCCESS = "New book added: %1$s";
+    public static final String MESSAGE_SUCCESS = "New book added: %1$s.\n";
+    public static final String MESSAGE_SAME_ISBN_INCONSISTENT = "There already exists a book with isbn %1$s, "
+            + "but has different authors or name!\n";
 
     private final Book toAdd;
 
@@ -46,9 +48,13 @@ public class AddBookCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-
+        if (model.hasSameIsbnDiffAuthorsOrName(toAdd)) {
+            throw new CommandException(String.format(MESSAGE_SAME_ISBN_INCONSISTENT, toAdd.getIsbn()));
+        }
+        // Remove all requests for this isbn and notify all requesters who requested for a book with toAdd's isbn
+        String notification = model.deleteAllRequests(toAdd);
         model.addBook(toAdd);
-        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
+        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd) + notification);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/book/DeleteBookCommand.java
+++ b/src/main/java/seedu/address/logic/commands/book/DeleteBookCommand.java
@@ -23,6 +23,7 @@ public class DeleteBookCommand extends Command {
             + "Example: " + BOOK_COMMAND_GROUP + " " + DELETE_COMMAND_WORD + " 1";
 
     public static final String MESSAGE_DELETE_BOOK_SUCCESS = "Deleted Book: %1$s";
+    public static final String MESSAGE_DELETE_BORROWED_BOOK = "You cannot delete a book that is borrowed!";
 
     private final Index targetIndex;
 
@@ -43,8 +44,11 @@ public class DeleteBookCommand extends Command {
         }
 
         Book bookToDelete = lastShownList.get(targetIndex.getZeroBased());
-        model.deleteBook(bookToDelete);
+        if (bookToDelete.isBorrowed()) {
+            throw new CommandException(MESSAGE_DELETE_BORROWED_BOOK);
+        }
 
+        model.deleteBook(bookToDelete);
         return new CommandResult(String.format(MESSAGE_DELETE_BOOK_SUCCESS, bookToDelete));
     }
 

--- a/src/main/java/seedu/address/logic/commands/book/EditBookCommand.java
+++ b/src/main/java/seedu/address/logic/commands/book/EditBookCommand.java
@@ -26,6 +26,7 @@ import seedu.address.model.book.Book;
 import seedu.address.model.book.BookName;
 import seedu.address.model.book.BookStatus;
 import seedu.address.model.book.Isbn;
+import seedu.address.model.patron.Patron;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -96,8 +97,9 @@ public class EditBookCommand extends Command {
         Set<Tag> updatedTags = editBookDescriptor.getTags().orElse(bookToEdit.getTags());
         long updatedTimeAdded = bookToEdit.getTimeAdded();
         BookStatus bookStatus = bookToEdit.getBookStatus();
+        Set<Patron> requesters = bookToEdit.getRequesters();
 
-        return new Book(updatedName, updatedIsbn, updatedAuthor, updatedTags, updatedTimeAdded, bookStatus);
+        return new Book(updatedName, updatedIsbn, updatedAuthor, updatedTags, updatedTimeAdded, bookStatus, requesters);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/parser/book/AddBookCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/book/AddBookCommandParser.java
@@ -7,6 +7,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -50,7 +51,8 @@ public class AddBookCommandParser implements Parser<AddBookCommand> {
         List<Author> authorList = ParserUtil.parseAuthors(argMultimap.getAllValues(PREFIX_AUTHOR));
         BookStatus availableStatus = BookStatus.createAvailableBookStatus();
 
-        Book book = new Book(bookName, isbn, authorList, tagList, new Date().getTime(), availableStatus);
+        Book book = new Book(bookName, isbn, authorList, tagList, new Date().getTime(), availableStatus,
+                new HashSet<>());
 
         return new AddBookCommand(book);
     }

--- a/src/main/java/seedu/address/model/LibTask.java
+++ b/src/main/java/seedu/address/model/LibTask.java
@@ -98,6 +98,14 @@ public class LibTask implements ReadOnlyLibTask {
     }
 
     /**
+     * Returns true if there is some book in this LibTask's book list with the same isbn as {@code bookToCheck}.
+     */
+    public boolean hasSameIsbn(Book bookToCheck) {
+        requireNonNull(bookToCheck);
+        return books.hasSameIsbn(bookToCheck);
+    }
+
+    /**
      * Removes all book requests from all books in this LibTask's book list that has the same isbn as any book in
      * {@param booksToDelete}.
      *
@@ -141,6 +149,18 @@ public class LibTask implements ReadOnlyLibTask {
         requireNonNull(editedBook);
 
         books.setBook(target, editedBook);
+    }
+
+    /**
+     * Replaces the given book {@code target} with {@code editedBook}. If there are any other books with the same isbn
+     * as {@code target}, update the authors and names of all those books to ensure consistency about books.
+     * {@code target} must exist in LibTask.
+     *
+     * @return True if some other book other than target is modified for the sake of consistency.
+     */
+    public boolean setAndEditBook(Book target, Book editedBook) {
+        requireAllNonNull(target, editedBook);
+        return books.setAndEditBook(target, editedBook);
     }
 
     /**

--- a/src/main/java/seedu/address/model/LibTask.java
+++ b/src/main/java/seedu/address/model/LibTask.java
@@ -89,6 +89,25 @@ public class LibTask implements ReadOnlyLibTask {
     }
 
     /**
+     * Returns true if there is some book in this LibTask's book list with the same isbn, but different book name or
+     * different set of authors as {@code bookToCheck}.
+     */
+    public boolean hasSameIsbnDiffAuthorsOrName(Book bookToCheck) {
+        requireNonNull(bookToCheck);
+        return books.hasSameIsbnDiffAuthorsOrName(bookToCheck);
+    }
+
+    /**
+     * Removes all book requests from all books in this LibTask's book list that has the same isbn as any book in
+     * {@param booksToDelete}.
+     *
+     * @return A message string representing the notifications for distinct book request that were deleted.
+     */
+    public String deleteAllRequests(Book ... booksToDelete) {
+        return books.deleteAllRequests(booksToDelete);
+    }
+
+    /**
      * Adds a patron to LibTask.
      * The patron must not already exist in LibTask.
      */

--- a/src/main/java/seedu/address/model/LibTask.java
+++ b/src/main/java/seedu/address/model/LibTask.java
@@ -165,11 +165,13 @@ public class LibTask implements ReadOnlyLibTask {
 
     /**
      * Replaces all books borrowed by {@code borrower} with the same book, but with available status in LibTask.
+     *
+     * @return The list of available books that were returned by {@code borrower}
      */
-    public void returnAllBorrowedBooks(Patron borrower) {
+    public List<Book> returnAllBorrowedBooks(Patron borrower) {
         requireNonNull(borrower);
 
-        books.returnAllBorrowedBooks(borrower);
+        return books.returnAllBorrowedBooks(borrower);
     }
 
     /**

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -1,16 +1,11 @@
 package seedu.address.model;
 
 import java.nio.file.Path;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.book.Book;
-import seedu.address.model.book.Isbn;
 import seedu.address.model.patron.Patron;
 
 /**
@@ -76,6 +71,11 @@ public interface Model {
     boolean hasSameIsbnDiffAuthorsOrName(Book bookToCheck);
 
     /**
+     * Returns true if there is some book in this model's book list with the same isbn as {@code bookToCheck}.
+     */
+    boolean hasSameIsbn(Book bookToCheck);
+
+    /**
      * Removes all book requests from all books in this model's book list that has the same isbn as any book in
      * {@param books}.
      *
@@ -119,6 +119,15 @@ public interface Model {
      * The book identity of {@code editedBook} must not be the same as another existing book in LibTask.
      */
     void setBook(Book target, Book editedBook);
+
+    /**
+     * Replaces the given book {@code target} with {@code editedBook}. If there are any other books with the same isbn
+     * as {@code target}, update the authors and names of all those books to ensure consistency about books.
+     * {@code target} must exist in LibTask.
+     *
+     * @return True if some other book other than target is modified for the sake of consistency.
+     */
+    boolean setAndEditBook(Book target, Book editedBook);
 
     /**
      * Replaces all books borrowed by {@code borrower} with the same book, but with available status in LibTask.

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -1,6 +1,7 @@
 package seedu.address.model;
 
 import java.nio.file.Path;
+import java.util.List;
 import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
@@ -131,8 +132,10 @@ public interface Model {
 
     /**
      * Replaces all books borrowed by {@code borrower} with the same book, but with available status in LibTask.
+     *
+     * @return The list of available books that were returned by {@code borrower}
      */
-    void returnAllBorrowedBooks(Patron borrower);
+    List<Book> returnAllBorrowedBooks(Patron borrower);
 
     /**
      * Returns true if the specified patron is currently borrowing at least one book.

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -1,11 +1,16 @@
 package seedu.address.model;
 
 import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.book.Book;
+import seedu.address.model.book.Isbn;
 import seedu.address.model.patron.Patron;
 
 /**
@@ -63,6 +68,20 @@ public interface Model {
      * Returns true if a book with the same identity as {@code book} exists in LibTask.
      */
     boolean hasBook(Book book);
+
+    /**
+     * Returns true if there is some book in this model's book list with the same isbn, but different book name or
+     * different set of authors as {@code bookToCheck}.
+     */
+    boolean hasSameIsbnDiffAuthorsOrName(Book bookToCheck);
+
+    /**
+     * Removes all book requests from all books in this model's book list that has the same isbn as any book in
+     * {@param books}.
+     *
+     * @return A message string representing the notifications for distinct book request that were deleted.
+     */
+    String deleteAllRequests(Book ... books);
 
     /**
      * Deletes the given patron.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.nio.file.Path;
+import java.util.List;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
@@ -162,9 +163,9 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public void returnAllBorrowedBooks(Patron borrower) {
+    public List<Book> returnAllBorrowedBooks(Patron borrower) {
         requireNonNull(borrower);
-        libTask.returnAllBorrowedBooks(borrower);
+        return libTask.returnAllBorrowedBooks(borrower);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -109,6 +109,12 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public boolean hasSameIsbn(Book bookToCheck) {
+        requireNonNull(bookToCheck);
+        return libTask.hasSameIsbn(bookToCheck);
+    }
+
+    @Override
     public String deleteAllRequests(Book ... books) {
         return libTask.deleteAllRequests(books);
     }
@@ -147,6 +153,12 @@ public class ModelManager implements Model {
         requireAllNonNull(target, editedBook);
 
         libTask.setBook(target, editedBook);
+    }
+
+    @Override
+    public boolean setAndEditBook(Book target, Book editedBook) {
+        requireAllNonNull(target, editedBook);
+        return libTask.setAndEditBook(target, editedBook);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -103,6 +103,17 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public boolean hasSameIsbnDiffAuthorsOrName(Book bookToCheck) {
+        requireNonNull(bookToCheck);
+        return libTask.hasSameIsbnDiffAuthorsOrName(bookToCheck);
+    }
+
+    @Override
+    public String deleteAllRequests(Book ... books) {
+        return libTask.deleteAllRequests(books);
+    }
+
+    @Override
     public void deletePatron(Patron target) {
         libTask.removePatron(target);
     }

--- a/src/main/java/seedu/address/model/book/Author.java
+++ b/src/main/java/seedu/address/model/book/Author.java
@@ -3,6 +3,8 @@ package seedu.address.model.book;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
+import java.util.Arrays;
+
 /**
  * Represents a Author in LibTask.
  * Guarantees: immutable; is valid as declared in {@link #isValidAuthor(String)}
@@ -50,6 +52,21 @@ public class Author {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
             || (other instanceof Author // instanceof handles nulls
-            && fullAuthorName.equals(((Author) other).fullAuthorName)); // state check
+            && getAuthorNameForComparison().equals(((Author) other).getAuthorNameForComparison())); // state check
+    }
+
+    @Override
+    public int hashCode() {
+        return getAuthorNameForComparison().hashCode();
+    }
+
+    /**
+     * Returns the full name of the author, converted to lowercase and without whitespaces.
+     */
+    private String getAuthorNameForComparison() {
+        StringBuilder builder = new StringBuilder();
+        String[] splittedName = fullAuthorName.trim().toLowerCase().split("\\s+");
+        Arrays.stream(splittedName).forEachOrdered(s -> builder.append(s));
+        return builder.toString();
     }
 }

--- a/src/main/java/seedu/address/model/book/Book.java
+++ b/src/main/java/seedu/address/model/book/Book.java
@@ -54,6 +54,14 @@ public class Book {
                 originalBook.getTags(), originalBook.getTimeAdded(), updatedBookStatus, originalBook.getRequesters());
     }
 
+    /**
+     * Returns a Book that is same as {@code originalBook} in every aspect, but with no requesters.
+     */
+    public Book getBookWithEmptyRequest() {
+        return new Book(getBookName(), getIsbn(), getAuthors(), getTags(), getTimeAdded(), getBookStatus(),
+                new HashSet<>());
+    }
+
     public BookName getBookName() {
         return bookName;
     }
@@ -169,6 +177,14 @@ public class Book {
     }
 
     /**
+     * Returns true if both books have the same book name.
+     * Book names are considered to be equal based on {@link BookName#equals(Object)}
+     */
+    public boolean hasSameName(Book other) {
+        return bookName.equals(other.bookName);
+    }
+
+    /**
      * Returns true if both books have the same identity and data fields.
      * This defines a stronger notion of equality between two books.
      */
@@ -208,7 +224,7 @@ public class Book {
         List<Author> authors = getAuthors();
         if (!authors.isEmpty()) {
             builder.append("; Authors: ");
-            authors.forEach(builder::append);
+            authors.forEach(author -> builder.append(author.toString() + " "));
         }
 
         Set<Tag> tags = getTags();

--- a/src/main/java/seedu/address/model/book/Book.java
+++ b/src/main/java/seedu/address/model/book/Book.java
@@ -1,5 +1,6 @@
 package seedu.address.model.book;
 
+import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.ArrayList;
@@ -60,6 +61,16 @@ public class Book {
     public Book getBookWithEmptyRequest() {
         return new Book(getBookName(), getIsbn(), getAuthors(), getTags(), getTimeAdded(), getBookStatus(),
                 new HashSet<>());
+    }
+
+    /**
+     * Returns a Book that is consistent with {@code editedBook}, but has all other fields same as this book.
+     * Two books are consistent if they either do not have the same isbn, or have the same isbn, book name, and authors.
+     */
+    public Book getConsistentReplacement(Book editedBook) {
+        requireNonNull(editedBook);
+        return new Book(editedBook.getBookName(), editedBook.getIsbn(), editedBook.getAuthors(), getTags(),
+                getTimeAdded(), getBookStatus(), getRequesters());
     }
 
     public BookName getBookName() {

--- a/src/main/java/seedu/address/model/book/Book.java
+++ b/src/main/java/seedu/address/model/book/Book.java
@@ -132,6 +132,26 @@ public class Book {
     }
 
     /**
+     * Returns true if both books have the same set of authors.
+     * Authors are considered to be equal based on {@link Author#equals(Object)}
+     */
+    public boolean hasSameAuthors(Book other) {
+        HashSet<Author> thisAuthors = new HashSet<>();
+        thisAuthors.addAll(authors);
+        HashSet<Author> otherAuthors = new HashSet<>();
+        otherAuthors.addAll(other.authors);
+        return thisAuthors.equals(otherAuthors);
+    }
+
+    /**
+     * Returns true if both books have the same isbn.
+     * Isbn are considered to be equal based on {@link Isbn#equals(Object)}
+     */
+    public boolean hasSameIsbn(Book other) {
+        return isbn.equals(other.isbn);
+    }
+
+    /**
      * Returns true if both books have the same identity and data fields.
      * This defines a stronger notion of equality between two books.
      */
@@ -147,7 +167,7 @@ public class Book {
 
         Book otherBook = (Book) other;
         return otherBook.getBookName().equals(getBookName())
-                && otherBook.getAuthors().equals(getAuthors())
+                && hasSameAuthors(otherBook)
                 && otherBook.getTags().equals(getTags())
                 && otherBook.getIsbn().equals(getIsbn())
                 && otherBook.timeAdded == timeAdded

--- a/src/main/java/seedu/address/model/book/Book.java
+++ b/src/main/java/seedu/address/model/book/Book.java
@@ -29,19 +29,21 @@ public class Book {
     private final List<Author> authors = new ArrayList<Author>();
     private final Set<Tag> tags = new HashSet<Tag>();
     private final BookStatus bookStatus;
+    private final Set<Patron> requesters = new HashSet<>();
 
     /**
      * Every field must be present and not null.
      */
     public Book(BookName bookName, Isbn isbn, List<Author> authors, Set<Tag> tags, long timeAdded,
-                BookStatus bookStatus) {
-        requireAllNonNull(bookName, isbn, authors, tags, bookStatus);
+                BookStatus bookStatus, Set<Patron> requesters) {
+        requireAllNonNull(bookName, isbn, authors, tags, bookStatus, requesters);
         this.bookName = bookName;
         this.isbn = isbn;
         this.authors.addAll(authors);
         this.tags.addAll(tags);
         this.timeAdded = timeAdded;
         this.bookStatus = bookStatus;
+        this.requesters.addAll(requesters);
     }
 
     /**
@@ -49,7 +51,7 @@ public class Book {
      */
     public Book(Book originalBook, BookStatus updatedBookStatus) {
         this (originalBook.getBookName(), originalBook.getIsbn(), originalBook.getAuthors(),
-                originalBook.getTags(), originalBook.getTimeAdded(), updatedBookStatus);
+                originalBook.getTags(), originalBook.getTimeAdded(), updatedBookStatus, originalBook.getRequesters());
     }
 
     public BookName getBookName() {
@@ -74,6 +76,14 @@ public class Book {
      */
     public Set<Tag> getTags() {
         return Collections.unmodifiableSet(tags);
+    }
+
+    /**
+     * Returns an immutable requester set, which throws {@code UnsupportedOperationException}
+     * if modification is attempted.
+     */
+    public Set<Patron> getRequesters() {
+        return Collections.unmodifiableSet(requesters);
     }
 
     public BookStatus getBookStatus() {
@@ -117,6 +127,13 @@ public class Book {
             return false;
         }
         return bookStatus.getBorrower().map(p -> p.equals(patron)).orElse(false);
+    }
+
+    /**
+     * Returns true if this book is requested by the specified patron.
+     */
+    public boolean isRequestedBy(Patron patron) {
+        return requesters.contains(patron);
     }
 
     /**
@@ -171,13 +188,14 @@ public class Book {
                 && otherBook.getTags().equals(getTags())
                 && otherBook.getIsbn().equals(getIsbn())
                 && otherBook.timeAdded == timeAdded
-                && otherBook.bookStatus.equals(bookStatus);
+                && otherBook.bookStatus.equals(bookStatus)
+                && otherBook.requesters.equals(requesters);
     }
 
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(bookName, isbn, authors, tags, timeAdded, bookStatus);
+        return Objects.hash(bookName, isbn, authors, tags, timeAdded, bookStatus, requesters);
     }
 
     @Override
@@ -199,6 +217,10 @@ public class Book {
             tags.forEach(builder::append);
         }
         builder.append("; Status: ").append(bookStatus.toString());
+        if (!requesters.isEmpty()) {
+            builder.append("; Requested by: ");
+            requesters.forEach(r -> builder.append(r.getName()));
+        }
         return builder.toString();
     }
 }

--- a/src/main/java/seedu/address/model/book/BookList.java
+++ b/src/main/java/seedu/address/model/book/BookList.java
@@ -3,6 +3,7 @@ package seedu.address.model.book;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -110,15 +111,20 @@ public class BookList implements Iterable<Book> {
 
     /**
      * Replaces all books borrowed by {@code borrower} with the same book, but with available status in this book list.
+     *
+     * @return The list of available books that were returned by {@code borrower}
      */
-    public void returnAllBorrowedBooks(Patron borrower) {
+    public List<Book> returnAllBorrowedBooks(Patron borrower) {
+        ArrayList<Book> returnedBooks = new ArrayList<>();
         for (Book book : internalList) {
             if (!book.isBorrowedBy(borrower)) {
                 continue;
             }
             Book updatedAvailableBook = new Book(book, BookStatus.createAvailableBookStatus());
             setBook(book, updatedAvailableBook);
+            returnedBooks.add(updatedAvailableBook);
         }
+        return returnedBooks;
     }
 
     /**

--- a/src/main/java/seedu/address/model/book/BookList.java
+++ b/src/main/java/seedu/address/model/book/BookList.java
@@ -60,6 +60,30 @@ public class BookList implements Iterable<Book> {
     }
 
     /**
+     * Replaces the given book {@code target} with {@code editedBook}. If there are any other books with the same isbn
+     * as {@code target}, update the authors and names of all those books to ensure consistency about books.
+     * {@code target} must exist in LibTask.
+     *
+     * @return True if some other book other than target is modified for the sake of consistency.
+     */
+    public boolean setAndEditBook(Book target, Book editedBook) {
+        // setBook must be done first, otherwise tags will not be updated
+        setBook(target, editedBook);
+        boolean hasModifiedOtherBooks = false;
+        for (Book book : internalList) {
+            if (!book.hasSameIsbn(target) || book.equals(editedBook)) {
+                continue;
+            }
+            if (!book.hasSameIsbn(editedBook) || !book.hasSameName(editedBook) || !book.hasSameAuthors(editedBook)) {
+                Book updatedConsistentBook = book.getConsistentReplacement(editedBook);
+                setBook(book, updatedConsistentBook);
+                hasModifiedOtherBooks = true;
+            }
+        }
+        return hasModifiedOtherBooks;
+    }
+
+    /**
      * Removes the equivalent book from the list.
      * The book must exist in the list.
      */
@@ -98,12 +122,19 @@ public class BookList implements Iterable<Book> {
     }
 
     /**
-     * Returns true if there is some book in this book list with the same isbn, but different book name or
+     * Returns true if there is some other book in this book list with the same isbn, but different book name or
      * different set of authors as {@code bookToCheck}.
      */
     public boolean hasSameIsbnDiffAuthorsOrName(Book bookToCheck) {
-        return internalList.stream().anyMatch(book -> book.hasSameIsbn(bookToCheck) &&
-                (!book.hasSameAuthors(bookToCheck) || !book.hasSameName(bookToCheck)));
+        return internalList.stream().anyMatch(book -> book.hasSameIsbn(bookToCheck)
+                && (!book.hasSameAuthors(bookToCheck) || !book.hasSameName(bookToCheck)));
+    }
+
+    /**
+     * Returns true if there is some book in this book list with the same isbn as {@code bookToCheck}.
+     */
+    public boolean hasSameIsbn(Book bookToCheck) {
+        return internalList.stream().anyMatch(book -> book.hasSameIsbn(bookToCheck));
     }
 
     /**

--- a/src/main/java/seedu/address/model/book/BookName.java
+++ b/src/main/java/seedu/address/model/book/BookName.java
@@ -3,6 +3,8 @@ package seedu.address.model.book;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
+import java.util.Arrays;
+
 /**
  * Represents a Book's name in LibTask.
  * Guarantees: immutable; is valid as declared in {@link #isValidBookName(String)}
@@ -49,11 +51,21 @@ public class BookName {
     public boolean equals(Object other) {
         return other == this
                 || (other instanceof BookName) //instanceof handle nulls
-                && fullBookName.equals(((BookName) other).fullBookName);
+                && getBookNameForComparison().equals(((BookName) other).getBookNameForComparison());
     }
 
     @Override
     public int hashCode() {
-        return fullBookName.hashCode();
+        return getBookNameForComparison().hashCode();
+    }
+
+    /**
+     * Returns the book name, converted to lowercase and without whitespaces.
+     */
+    private String getBookNameForComparison() {
+        StringBuilder builder = new StringBuilder();
+        String[] splittedName = fullBookName.trim().toLowerCase().split("\\s+");
+        Arrays.stream(splittedName).forEachOrdered(s -> builder.append(s));
+        return builder.toString();
     }
 }

--- a/src/main/java/seedu/address/model/book/BookStatus.java
+++ b/src/main/java/seedu/address/model/book/BookStatus.java
@@ -139,7 +139,7 @@ public class BookStatus {
         final StringBuilder builder = new StringBuilder();
         builder.append(bookStatusType.toString());
         if (isBorrowed()) {
-            builder.append("; Borrowed by: ").append(borrower.map(Patron::toString).get());
+            builder.append("; Borrowed by: ").append(borrower.map(b -> b.getName()).get());
             builder.append("; Borrow Date: ").append(borrowDate.map(date -> STATUS_DATE_FORMAT.format(date)).get());
             builder.append("; Return Date: ").append(returnDate.map(date -> STATUS_DATE_FORMAT.format(date)).get());
         }

--- a/src/main/java/seedu/address/model/book/Isbn.java
+++ b/src/main/java/seedu/address/model/book/Isbn.java
@@ -99,7 +99,7 @@ public class Isbn {
 
     @Override
     public String toString() {
-        return isbn;
+        return removeHyphen(isbn);
     }
 
     @Override
@@ -109,5 +109,8 @@ public class Isbn {
                 && removeHyphen(isbn).equals(removeHyphen(((Isbn) other).isbn))); // state check
     }
 
-
+    @Override
+    public int hashCode() {
+        return removeHyphen(isbn).hashCode();
+    }
 }

--- a/src/main/java/seedu/address/model/patron/Patron.java
+++ b/src/main/java/seedu/address/model/patron/Patron.java
@@ -74,6 +74,10 @@ public class Patron {
                 && otherPatron.getId().equals(getId());
     }
 
+    public Patron copy() {
+        return new Patron(name, phone, email, id, getTags());
+    }
+
     /**
      * Returns true if both patrons have the same identity and data fields.
      * This defines a stronger notion of equality between two patrons.

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -4,6 +4,7 @@ import static seedu.address.model.book.BookStatusType.BORROWED;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -65,31 +66,31 @@ public class SampleDataUtil {
             new Book(new BookName("Harry Potter and The Philosopher's Stone"), new Isbn("978-71617-018-8-5"),
                 getAuthorList("J. K. Rowling"),
                 getTagSet("Adventure", "Magic"), SAMPLE_BOOK_CREATED_TIME,
-                    SAMPLE_AVAILABLE_STATUS),
+                    SAMPLE_AVAILABLE_STATUS, new HashSet<>()),
             new Book(new BookName("The Hunger Games: MockingJay"), new Isbn("9786029293883"),
                 getAuthorList("Suzanne Collins"),
                 getTagSet("Thriller", "Scifi", "Adventure"), SAMPLE_BOOK_CREATED_TIME,
-                    getSampleBorrowedStatus()),
+                    getSampleBorrowedStatus(), new HashSet<>()),
             new Book(new BookName("Introduction to Algorithms"), new Isbn("978-03-71-88850-6"),
                 getAuthorList("Cormen", "Leiserson", "Rivest", "Stein"),
                 getTagSet("ComputerScience", "Mathematics"), SAMPLE_BOOK_CREATED_TIME,
-                    SAMPLE_AVAILABLE_STATUS),
+                    SAMPLE_AVAILABLE_STATUS, new HashSet<>()),
             new Book(new BookName("The Little Book of Semaphores"), new Isbn("4992719864"),
                 getAuthorList(),
                 getTagSet("ComputerScience", "Technology"), SAMPLE_BOOK_CREATED_TIME,
-                    getSampleBorrowedStatus()),
+                    getSampleBorrowedStatus(), new HashSet<>()),
             new Book(new BookName("The Maze Runner"), new Isbn("1-474-59282-1"),
                 getAuthorList("James Dashner1", "James Dashner2", "James Dashner3"),
                 getTagSet("Adventure", "Romance", "Scifi"), SAMPLE_BOOK_CREATED_TIME,
-                    SAMPLE_AVAILABLE_STATUS),
+                    SAMPLE_AVAILABLE_STATUS, new HashSet<>()),
             new Book(new BookName("Artificial Intelligence: A Modern Approach"), new Isbn("9780131038059"),
                 getAuthorList("Peter Norvig", "Stuart J. Russell"),
                 getTagSet("Technology"), SAMPLE_BOOK_CREATED_TIME,
-                    SAMPLE_AVAILABLE_STATUS),
+                    SAMPLE_AVAILABLE_STATUS, new HashSet<>()),
             new Book(new BookName("Cinderella"), new Isbn("9781409580454"),
                 getAuthorList(),
                 getTagSet(), SAMPLE_BOOK_CREATED_TIME,
-                    getSampleBorrowedStatus())
+                    getSampleBorrowedStatus(), new HashSet<>())
         };
     }
 
@@ -120,5 +121,14 @@ public class SampleDataUtil {
         return Arrays.stream(strings)
                 .map(Author::new)
                 .collect(Collectors.toCollection(ArrayList::new));
+    }
+
+    /**
+     * Returns a requester set containing the list of requesters given.
+     */
+    public static Set<Patron> getRequesterSet(Patron... requesters) {
+        return Arrays.stream(requesters)
+                .map(r -> r.copy())
+                .collect(Collectors.toSet());
     }
 }

--- a/src/main/java/seedu/address/storage/JsonAdaptedBook.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedBook.java
@@ -15,6 +15,7 @@ import seedu.address.model.book.Book;
 import seedu.address.model.book.BookName;
 import seedu.address.model.book.BookStatus;
 import seedu.address.model.book.Isbn;
+import seedu.address.model.patron.Patron;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -28,6 +29,7 @@ class JsonAdaptedBook {
     private final List<JsonAdaptedTag> tagged = new ArrayList<>();
     private final String timeAdded;
     private final JsonAdaptedBookStatus bookStatus;
+    private final List<JsonAdaptedPatron> requesters = new ArrayList<>();
 
     /**
      * Constructs a {@code JsonAdaptedBook} with the given book details.
@@ -37,7 +39,8 @@ class JsonAdaptedBook {
         @JsonProperty("tagged") List<JsonAdaptedTag> tagged,
         @JsonProperty("authors") List<JsonAdaptedAuthor> authors,
         @JsonProperty("timeAdded") String timeAdded,
-        @JsonProperty("bookStatus") JsonAdaptedBookStatus bookStatus) {
+        @JsonProperty("bookStatus") JsonAdaptedBookStatus bookStatus,
+        @JsonProperty("requesters") List<JsonAdaptedPatron> requesters) {
         this.bookName = bookName;
         this.isbn = isbn;
         if (tagged != null) {
@@ -48,6 +51,9 @@ class JsonAdaptedBook {
         }
         this.bookStatus = bookStatus;
         this.timeAdded = timeAdded;
+        if (requesters != null) {
+            this.requesters.addAll(requesters);
+        }
     }
 
     /**
@@ -64,6 +70,9 @@ class JsonAdaptedBook {
                 .collect(Collectors.toList()));
         timeAdded = Long.toString(source.getTimeAdded());
         bookStatus = new JsonAdaptedBookStatus(source.getBookStatus());
+        requesters.addAll(source.getRequesters().stream()
+                .map(JsonAdaptedPatron::new)
+                .collect(Collectors.toList()));
     }
 
     /**
@@ -75,6 +84,10 @@ class JsonAdaptedBook {
         final List<Tag> bookTags = new ArrayList<>();
         for (JsonAdaptedTag tag : tagged) {
             bookTags.add(tag.toModelType());
+        }
+        final List<Patron> bookRequesters = new ArrayList<>();
+        for (JsonAdaptedPatron requester : requesters) {
+            bookRequesters.add(requester.toModelType());
         }
 
         final List<Author> bookAuthors = new ArrayList<>();
@@ -100,6 +113,7 @@ class JsonAdaptedBook {
         final Isbn modelIsbn = new Isbn(isbn);
 
         final Set<Tag> modelTags = new HashSet<>(bookTags);
+        final Set<Patron> modelRequesters = new HashSet<>(bookRequesters);
 
         if (bookStatus == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
@@ -112,7 +126,8 @@ class JsonAdaptedBook {
         }
         try {
             final long timeBookAdded = Long.parseLong(timeAdded);
-            return new Book(modelName, modelIsbn, bookAuthors, modelTags, timeBookAdded, modelBookStatus);
+            return new Book(modelName, modelIsbn, bookAuthors, modelTags, timeBookAdded, modelBookStatus,
+                    modelRequesters);
         } catch (NumberFormatException e) {
             throw new IllegalValueException(Book.TIME_ADDED_MESSAGE_CONSTRAINTS);
         }

--- a/src/test/data/JsonSerializableLibTaskTest/invalidBookLibTask.json
+++ b/src/test/data/JsonSerializableLibTaskTest/invalidBookLibTask.json
@@ -8,7 +8,8 @@
     "timeAdded" : "1646989653388",
     "bookStatus" : {
       "bookStatusType" : "Available"
-    }
+    },
+    "requesters" : []
   }, {
     "bookName" : "The Hunger Games: MockingJay",
     "isbn" : "9786029293883",
@@ -17,6 +18,7 @@
     "timeAdded" : "1646989653388",
     "bookStatus" : {
       "bookStatusType" : "Available"
-    }
+    },
+    "requesters" : []
   }]
 }

--- a/src/test/data/JsonSerializableLibTaskTest/lengthyBooksLibTask.json
+++ b/src/test/data/JsonSerializableLibTaskTest/lengthyBooksLibTask.json
@@ -10,7 +10,8 @@
     "timeAdded" : "1646989653388",
     "bookStatus" : {
       "bookStatusType" : "Available"
-    }
+    },
+    "requesters" : []
   }, {
     "bookName" : "Lorem Ipsum comes from a latin text written in 45BC by Roman statesman Lorem Ipsum comes from a latin text written in 45BC by Roman statesman Lorem Ipsum comes from a latin text written in 45BC by Roman statesman Lorem Ipsum comes from a latin text written in 45BC by Roman statesman Lorem Ipsum comes from a latin text written in 45BC by Roman statesman Lorem Ipsum comes from a latin text written in 45BC by Roman statesman",
     "isbn" : "0-545-01022-5",
@@ -22,7 +23,8 @@
     "timeAdded" : "1646989653388",
     "bookStatus" : {
       "bookStatusType" : "Available"
-    }
+    },
+    "requesters" : []
   }
   ]
 }

--- a/src/test/data/JsonSerializableLibTaskTest/typicalBooksLibTask.json
+++ b/src/test/data/JsonSerializableLibTaskTest/typicalBooksLibTask.json
@@ -51,7 +51,8 @@
     "timeAdded" : "1646989653388",
     "bookStatus" : {
       "bookStatusType" : "Available"
-    }
+    },
+    "requesters" : []
   }, {
     "bookName" : "The Little Book of Semaphores",
     "isbn" : "4992719864",
@@ -60,7 +61,8 @@
     "timeAdded" : "1646989653388",
     "bookStatus" : {
       "bookStatusType" : "Available"
-    }
+    },
+    "requesters" : []
   }, {
     "bookName" : "The Maze Runner",
     "isbn" : "1-474-59282-1",
@@ -69,7 +71,8 @@
     "timeAdded" : "1646989653388",
     "bookStatus" : {
       "bookStatusType" : "Available"
-    }
+    },
+    "requesters" : []
   }, {
     "bookName" : "Artificial Intelligence: A Modern Approach",
     "isbn" : "9780131038059",
@@ -87,7 +90,8 @@
       },
       "borrowDate" : "14-Feb-2022",
       "returnDate" : "28-Feb-2022"
-    }
+    },
+    "requesters" : []
   }, {
     "bookName" : "Cinderella",
     "isbn" : "9781409580454",
@@ -96,7 +100,8 @@
     "timeAdded" : "1646989653388",
     "bookStatus" : {
       "bookStatusType" : "Available"
-    }
+    },
+    "requesters" : []
   }
   ]
 }

--- a/src/test/data/JsonSerializableLibTaskTest/typicalPatronsLibTask.json
+++ b/src/test/data/JsonSerializableLibTaskTest/typicalPatronsLibTask.json
@@ -51,7 +51,8 @@
     "timeAdded" : "1646989653388",
     "bookStatus" : {
       "bookStatusType" : "Available"
-    }
+    },
+    "requesters" : []
   }, {
     "bookName" : "The Little Book of Semaphores",
     "isbn" : "4992719864",
@@ -60,7 +61,8 @@
     "timeAdded" : "1646989653388",
     "bookStatus" : {
       "bookStatusType" : "Available"
-    }
+    },
+    "requesters" : []
   }, {
     "bookName" : "The Maze Runner",
     "isbn" : "1-474-59282-1",
@@ -69,7 +71,8 @@
     "timeAdded" : "1646989653388",
     "bookStatus" : {
       "bookStatusType" : "Available"
-    }
+    },
+    "requesters" : []
   }, {
     "bookName" : "Artificial Intelligence: A Modern Approach",
     "isbn" : "9780131038059",
@@ -87,7 +90,8 @@
       },
       "borrowDate" : "14-Feb-2022",
       "returnDate" : "28-Feb-2022"
-    }
+    },
+    "requesters" : []
   }, {
     "bookName" : "Cinderella",
     "isbn" : "9781409580454",
@@ -96,7 +100,8 @@
     "timeAdded" : "1646989653388",
     "bookStatus" : {
       "bookStatusType" : "Available"
-    }
+    },
+    "requesters" : []
   }
   ]
 }

--- a/src/test/java/seedu/address/logic/commands/book/AddBookCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/book/AddBookCommandTest.java
@@ -244,7 +244,7 @@ public class AddBookCommandTest {
         }
 
         @Override
-        public void returnAllBorrowedBooks(Patron borrower) {
+        public List<Book> returnAllBorrowedBooks(Patron borrower) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/address/logic/commands/book/AddBookCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/book/AddBookCommandTest.java
@@ -4,8 +4,8 @@ import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.commons.core.Messages.MESSAGE_SAME_ISBN_INCONSISTENT;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
-import static seedu.address.logic.commands.book.AddBookCommand.MESSAGE_SAME_ISBN_INCONSISTENT;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPatrons.ALICE;
 import static seedu.address.testutil.TypicalPatrons.BOB;
@@ -209,6 +209,11 @@ public class AddBookCommandTest {
         }
 
         @Override
+        public boolean hasSameIsbn(Book bookToCheck) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public String deleteAllRequests(Book ... books) {
             throw new AssertionError("This method should not be called.");
         }
@@ -230,6 +235,11 @@ public class AddBookCommandTest {
 
         @Override
         public void setBook(Book target, Book editedBook) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean setAndEditBook(Book target, Book editedBook) {
             throw new AssertionError("This method should not be called.");
         }
 
@@ -308,8 +318,8 @@ public class AddBookCommandTest {
         @Override
         public boolean hasSameIsbnDiffAuthorsOrName(Book bookToCheck) {
             requireNonNull(bookToCheck);
-            return booksAdded.stream().anyMatch(book -> book.hasSameIsbn(bookToCheck) &&
-                    (!book.hasSameAuthors(bookToCheck) || !book.hasSameName(bookToCheck)));
+            return booksAdded.stream().anyMatch(book -> book.hasSameIsbn(bookToCheck)
+                    && (!book.hasSameAuthors(bookToCheck) || !book.hasSameName(bookToCheck)));
         }
 
         @Override

--- a/src/test/java/seedu/address/logic/commands/book/AddBookCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/book/AddBookCommandTest.java
@@ -4,23 +4,33 @@ import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.address.logic.commands.book.AddBookCommand.MESSAGE_SAME_ISBN_INCONSISTENT;
 import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalPatrons.ALICE;
+import static seedu.address.testutil.TypicalPatrons.BOB;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.LibTask;
 import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyLibTask;
 import seedu.address.model.ReadOnlyUserPrefs;
 import seedu.address.model.book.Book;
+import seedu.address.model.book.Isbn;
+import seedu.address.model.book.exceptions.BookNotFoundException;
 import seedu.address.model.patron.Patron;
 import seedu.address.testutil.BookBuilder;
 
@@ -40,6 +50,64 @@ public class AddBookCommandTest {
 
         assertEquals(String.format(AddBookCommand.MESSAGE_SUCCESS, validBook), commandResult.getFeedbackToUser());
         assertEquals(Arrays.asList(validBook), modelStub.booksAdded);
+    }
+
+    @Test
+    public void execute_bookWithSameIsbnExistButDifferentAuthor_throwsCommandException() throws CommandException {
+        ModelStubAcceptingBookAdded modelStub = new ModelStubAcceptingBookAdded();
+        Book validBook = new BookBuilder().build();
+        new AddBookCommand(validBook).execute(modelStub);
+
+        // Fails to add a book which isbn was already added, but has different author
+        Book validBookDiffAuthor = new BookBuilder(validBook).withAuthors("diff author").build();
+        AddBookCommand errorCommand = new AddBookCommand(validBookDiffAuthor);
+        String expectedMessage = String.format(MESSAGE_SAME_ISBN_INCONSISTENT, validBookDiffAuthor.getIsbn());
+        assertThrows(CommandException.class, expectedMessage, () -> errorCommand.execute(modelStub));
+    }
+
+    @Test
+    public void execute_bookWithSameIsbnExistButDifferentName_throwsCommandException() throws CommandException {
+        ModelStubAcceptingBookAdded modelStub = new ModelStubAcceptingBookAdded();
+        Book validBook = new BookBuilder().build();
+        new AddBookCommand(validBook).execute(modelStub);
+
+        // Fails to add a book which isbn was already added, but has different name
+        Book validBookDiffName = new BookBuilder(validBook).withName("diff author").build();
+        AddBookCommand errorCommand = new AddBookCommand(validBookDiffName);
+        String expectedMessage = String.format(MESSAGE_SAME_ISBN_INCONSISTENT, validBookDiffName.getIsbn());
+        assertThrows(CommandException.class, expectedMessage, () -> errorCommand.execute(modelStub));
+    }
+
+    @Test
+    public void execute_bookWithSameIsbnExistButDifferentTags_addSuccessful() throws CommandException {
+        ModelStubAcceptingBookAdded modelStub = new ModelStubAcceptingBookAdded();
+        Book validBook = new BookBuilder().build();
+        new AddBookCommand(validBook).execute(modelStub);
+
+        // Able to add book that has same isbn as existing books, but different tags
+        Book validBookDiffTags = new BookBuilder(validBook).withTags("difftag1", "difftag2").build();
+        CommandResult commandResult = new AddBookCommand(validBookDiffTags).execute(modelStub);
+        assertEquals(String.format(AddBookCommand.MESSAGE_SUCCESS, validBookDiffTags),
+                commandResult.getFeedbackToUser());
+        assertEquals(Arrays.asList(validBook, validBookDiffTags), modelStub.booksAdded);
+    }
+
+    @Test
+    public void execute_successfulDeleteRequest() throws CommandException {
+        ModelStubAcceptingBookAdded modelStub = new ModelStubAcceptingBookAdded();
+        Book validBook = new BookBuilder().withRequesters(ALICE, BOB).build();
+        new AddBookCommand(validBook).execute(modelStub);
+
+        // After a book that has same isbn as existing books is added, all requests for that isbn is removed
+        Book validBookCopy = new BookBuilder(validBook).withRequesters().build();
+        String expectedMessage = String.format(AddBookCommand.MESSAGE_SUCCESS, validBookCopy)
+                + String.format("You should notify %s about availability of %s\n",
+                BOB.getName(), validBook.getBookName())
+                + String.format("You should notify %s about availability of %s\n",
+                ALICE.getName(), validBook.getBookName());
+        CommandResult commandResult = new AddBookCommand(validBookCopy).execute(modelStub);
+        assertEquals(expectedMessage, commandResult.getFeedbackToUser());
+        assertEquals(Arrays.asList(validBookCopy, validBookCopy), modelStub.booksAdded);
     }
 
     @Test
@@ -136,6 +204,16 @@ public class AddBookCommandTest {
         }
 
         @Override
+        public boolean hasSameIsbnDiffAuthorsOrName(Book bookToCheck) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public String deleteAllRequests(Book ... books) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void deletePatron(Patron target) {
             throw new AssertionError("This method should not be called.");
         }
@@ -228,8 +306,60 @@ public class AddBookCommandTest {
         }
 
         @Override
+        public boolean hasSameIsbnDiffAuthorsOrName(Book bookToCheck) {
+            requireNonNull(bookToCheck);
+            return booksAdded.stream().anyMatch(book -> book.hasSameIsbn(bookToCheck) &&
+                    (!book.hasSameAuthors(bookToCheck) || !book.hasSameName(bookToCheck)));
+        }
+
+        @Override
+        public String deleteAllRequests(Book ... books) {
+            HashSet<Isbn> notifiedBooks = new HashSet<>(); // To prevent adding the same notification multiple times
+            StringBuilder builder = new StringBuilder();
+            List<Book> booksToProcess = Arrays.stream(books).collect(Collectors.toList());
+            for (Book book : booksToProcess) {
+                if (notifiedBooks.contains(book.getIsbn())) {
+                    continue;
+                }
+                notifiedBooks.add(book.getIsbn());
+                builder.append(deleteRequestSingleBook(book));
+            }
+            return builder.toString();
+        }
+
+        @Override
+        public void setBook(Book target, Book editedBook) {
+            requireAllNonNull(target, editedBook);
+
+            int index = booksAdded.indexOf(target);
+            if (index == -1) {
+                throw new BookNotFoundException();
+            }
+            booksAdded.set(index, editedBook);
+        }
+
+        @Override
         public ReadOnlyLibTask getLibTask() {
             return new LibTask();
+        }
+
+        private String deleteRequestSingleBook(Book bookToDelete) {
+            StringBuilder builder = new StringBuilder();
+            boolean hasNotified = false; // flag to prevent appending the same notification many times
+            for (Book book : booksAdded) {
+                if (!book.hasSameIsbn(bookToDelete) || book.getRequesters().isEmpty()) {
+                    continue;
+                }
+                if (!hasNotified) {
+                    book.getRequesters().stream().forEach(requester ->
+                        builder.append(String.format("You should notify %s about availability of %s\n",
+                                requester.getName(), book.getBookName())));
+                    hasNotified = true;
+                }
+                Book updatedBookEmptyRequest = book.getBookWithEmptyRequest();
+                setBook(book, updatedBookEmptyRequest);
+            }
+            return builder.toString();
         }
     }
 }

--- a/src/test/java/seedu/address/logic/commands/book/DeleteBookCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/book/DeleteBookCommandTest.java
@@ -6,6 +6,7 @@ import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showBookAtIndex;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_BOOK;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FOURTH_BOOK;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_BOOK;
 
 import org.junit.jupiter.api.Test;
@@ -74,6 +75,12 @@ public class DeleteBookCommandTest {
         DeleteBookCommand deleteCommand = new DeleteBookCommand(outOfBoundIndex);
 
         assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_BOOK_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_deleteBorrowedBook_throwsCommandException() {
+        DeleteBookCommand deleteCommand = new DeleteBookCommand(INDEX_FOURTH_BOOK); // the fourth book is borrowed
+        assertCommandFailure(deleteCommand, model, DeleteBookCommand.MESSAGE_DELETE_BORROWED_BOOK);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/book/EditBookCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/book/EditBookCommandTest.java
@@ -167,38 +167,6 @@ public class EditBookCommandTest {
     }
 
     @Test
-    public void execute_duplicateBookUnfilteredList_success() {
-        Book firstBook = model.getFilteredBookList().get(INDEX_FIRST_BOOK.getZeroBased());
-        Book editedBook = new BookBuilder(firstBook).build();
-        EditBookDescriptor bookDescriptor = new EditBookDescriptorBuilder(firstBook).build();
-        EditBookCommand editBookCommand = new EditBookCommand(INDEX_SECOND_BOOK, bookDescriptor);
-
-        String expectedMessage = String.format(EditBookCommand.MESSAGE_EDIT_BOOK_SUCCESS, editedBook);
-
-        Model expectedModel = new ModelManager(new LibTask(model.getLibTask()), new UserPrefs());
-        expectedModel.setBook(model.getFilteredBookList().get(1), editedBook);
-
-        assertCommandSuccess(editBookCommand, model, expectedMessage, expectedModel);
-    }
-
-    @Test
-    public void execute_duplicateBookFilteredList_success() {
-        showBookAtIndex(model, INDEX_FIRST_BOOK);
-
-        Book bookInList = model.getLibTask().getBookList().get(INDEX_SECOND_BOOK.getZeroBased());
-        EditBookCommand editBookCommand = new EditBookCommand(INDEX_FIRST_BOOK,
-                new EditBookDescriptorBuilder(bookInList).build());
-        Book editedBook = new BookBuilder(bookInList).build();
-
-        String expectedMessage = String.format(EditBookCommand.MESSAGE_EDIT_BOOK_SUCCESS, editedBook);
-
-        Model expectedModel = new ModelManager(new LibTask(model.getLibTask()), new UserPrefs());
-        expectedModel.setBook(model.getFilteredBookList().get(0), editedBook);
-
-        assertCommandSuccess(editBookCommand, model, expectedMessage, expectedModel);
-    }
-
-    @Test
     public void execute_invalidBookIndexUnfilteredList_failure() {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredBookList().size() + 1);
         EditBookDescriptor bookDescriptor = new EditBookDescriptorBuilder()
@@ -206,6 +174,19 @@ public class EditBookCommandTest {
         EditBookCommand editBookCommand = new EditBookCommand(outOfBoundIndex, bookDescriptor);
 
         assertCommandFailure(editBookCommand, model, Messages.MESSAGE_INVALID_BOOK_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_hasExistingIsbn_throwsCommandException() {
+        Index indexLastBook = Index.fromOneBased(model.getFilteredBookList().size());
+        Book lastBook = model.getFilteredBookList().get(indexLastBook.getZeroBased());
+
+        Book firstBook = model.getFilteredBookList().get(0);
+        String existingIsbn = firstBook.getIsbn().toString();
+        EditBookDescriptor bookDescriptor = new EditBookDescriptorBuilder().withIsbn(existingIsbn).build();
+        EditBookCommand editBookCommand = new EditBookCommand(indexLastBook, bookDescriptor);
+
+        assertCommandFailure(editBookCommand, model, EditBookCommand.MESSAGE_SAME_ISBN);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/patron/AddPatronCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/patron/AddPatronCommandTest.java
@@ -9,6 +9,7 @@ import static seedu.address.testutil.Assert.assertThrows;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
@@ -182,7 +183,7 @@ public class AddPatronCommandTest {
         }
 
         @Override
-        public void returnAllBorrowedBooks(Patron borrower) {
+        public List<Book> returnAllBorrowedBooks(Patron borrower) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/address/logic/commands/patron/AddPatronCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/patron/AddPatronCommandTest.java
@@ -147,6 +147,11 @@ public class AddPatronCommandTest {
         }
 
         @Override
+        public boolean hasSameIsbn(Book bookToCheck) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public String deleteAllRequests(Book ... books) {
             throw new AssertionError("This method should not be called.");
         }
@@ -168,6 +173,11 @@ public class AddPatronCommandTest {
 
         @Override
         public void setBook(Book target, Book editedBook) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean setAndEditBook(Book target, Book editedBook) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/address/logic/commands/patron/AddPatronCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/patron/AddPatronCommandTest.java
@@ -142,6 +142,16 @@ public class AddPatronCommandTest {
         }
 
         @Override
+        public boolean hasSameIsbnDiffAuthorsOrName(Book bookToCheck) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public String deleteAllRequests(Book ... books) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void deletePatron(Patron target) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/address/model/LibTaskTest.java
+++ b/src/test/java/seedu/address/model/LibTaskTest.java
@@ -8,8 +8,10 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_BOOK_NAME_HUNGE
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ISBN_HUNGER_GAMES;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_SCIFI;
+import static seedu.address.model.util.SampleDataUtil.getSampleBorrowedStatus;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalBooks.HARRY_POTTER;
+import static seedu.address.testutil.TypicalBooks.HUNGER_GAMES;
 import static seedu.address.testutil.TypicalPatrons.ALICE;
 
 import java.util.ArrayList;
@@ -133,8 +135,33 @@ public class LibTaskTest {
     public void hasSameIsbnDiffAuthorsOrName_consistentBook_returnsFalse() {
         libTask.addBook(HARRY_POTTER);
         // book with same name but different isbn is consistent
-            Book consistentBook = new BookBuilder(HARRY_POTTER).withIsbn(VALID_ISBN_HUNGER_GAMES).build();
+        Book consistentBook = new BookBuilder(HARRY_POTTER).withIsbn(VALID_ISBN_HUNGER_GAMES).build();
         assertFalse(libTask.hasSameIsbnDiffAuthorsOrName(consistentBook));
+    }
+
+    @Test
+    public void setAndEditBook_nullTarget_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> libTask.setAndEditBook(null, HARRY_POTTER));
+    }
+
+    @Test
+    public void setAndEditBook_nullTEditedBook_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> libTask.setAndEditBook(HARRY_POTTER, null));
+    }
+
+    @Test
+    public void hasSameIsbn_noSameIsbn_returnsFalse() {
+        libTask.addBook(HARRY_POTTER);
+        assertFalse(libTask.hasSameIsbn(HUNGER_GAMES));
+    }
+
+    @Test
+    public void hasSameIsbn_hasSameIsbn_returnsTrue() {
+        libTask.addBook(HARRY_POTTER);
+        Book allFieldsDifferentExceptIsbn = new BookBuilder(HARRY_POTTER).withName(VALID_BOOK_NAME_HUNGER_GAMES)
+                .withTags().withAuthors().withRequesters(ALICE).withBookStatus(getSampleBorrowedStatus())
+                .withTimeAdded(12345).build();
+        assertTrue(libTask.hasSameIsbn(allFieldsDifferentExceptIsbn));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/LibTaskTest.java
+++ b/src/test/java/seedu/address/model/LibTaskTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_AUTHOR_SUZANNE_COLLINS;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_BOOK_NAME_HUNGER_GAMES;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ISBN_HUNGER_GAMES;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_SCIFI;
 import static seedu.address.testutil.Assert.assertThrows;
@@ -114,6 +115,26 @@ public class LibTaskTest {
                 .withTags(VALID_TAG_SCIFI)
                 .build();
         assertTrue(libTask.hasBook(editedHarryPotter));
+    }
+
+    @Test
+    public void hasSameIsbnDiffAuthorsOrName_nullBook_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> libTask.hasSameIsbnDiffAuthorsOrName(null));
+    }
+
+    @Test
+    public void hasSameIsbnDiffAuthorsOrName_hasInconsistentBook_returnsTrue() {
+        libTask.addBook(HARRY_POTTER);
+        Book inconsistentBook = new BookBuilder(HARRY_POTTER).withName("diffname").build();
+        assertTrue(libTask.hasSameIsbnDiffAuthorsOrName(inconsistentBook));
+    }
+
+    @Test
+    public void hasSameIsbnDiffAuthorsOrName_consistentBook_returnsFalse() {
+        libTask.addBook(HARRY_POTTER);
+        // book with same name but different isbn is consistent
+            Book consistentBook = new BookBuilder(HARRY_POTTER).withIsbn(VALID_ISBN_HUNGER_GAMES).build();
+        assertFalse(libTask.hasSameIsbnDiffAuthorsOrName(consistentBook));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -3,6 +3,7 @@ package seedu.address.model;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ISBN_HUNGER_GAMES;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_BOOKS;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PATRONS;
 import static seedu.address.testutil.Assert.assertThrows;
@@ -17,8 +18,10 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.model.book.Book;
 import seedu.address.model.book.BookNameContainsKeywordsPredicate;
 import seedu.address.model.patron.NameContainsKeywordsPredicate;
+import seedu.address.testutil.BookBuilder;
 import seedu.address.testutil.LibTaskBuilder;
 
 public class ModelManagerTest {
@@ -105,6 +108,26 @@ public class ModelManagerTest {
     public void hasBook_bookInLibTask_returnsTrue() {
         modelManager.addBook(HARRY_POTTER);
         assertTrue(modelManager.hasBook(HARRY_POTTER));
+    }
+
+    @Test
+    public void hasSameIsbnDiffAuthorsOrName_nullBook_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> modelManager.hasSameIsbnDiffAuthorsOrName(null));
+    }
+
+    @Test
+    public void hasSameIsbnDiffAuthorsOrName_hasInconsistentBook_returnsTrue() {
+        modelManager.addBook(HARRY_POTTER);
+        Book inconsistentBook = new BookBuilder(HARRY_POTTER).withName("diffname").build();
+        assertTrue(modelManager.hasSameIsbnDiffAuthorsOrName(inconsistentBook));
+    }
+
+    @Test
+    public void hasSameIsbnDiffAuthorsOrName_consistentBook_returnsFalse() {
+        modelManager.addBook(HARRY_POTTER);
+        // book with same name but different isbn is consistent
+        Book consistentBook = new BookBuilder(HARRY_POTTER).withIsbn(VALID_ISBN_HUNGER_GAMES).build();
+        assertFalse(modelManager.hasSameIsbnDiffAuthorsOrName(consistentBook));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/book/AuthorTest.java
+++ b/src/test/java/seedu/address/model/book/AuthorTest.java
@@ -1,8 +1,13 @@
 package seedu.address.model.book;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
+
+import java.util.ArrayList;
+import java.util.HashSet;
 
 import org.junit.jupiter.api.Test;
 
@@ -36,5 +41,42 @@ public class AuthorTest {
         assertTrue(Author.isValidAuthor("123")); // numbers only
         assertTrue(Author.isValidAuthor("Queen Elizabeth 1")); // alphanumeric characters
         assertTrue(Author.isValidAuthor("J.K.Rowling")); // with dot character
+    }
+
+    @Test
+    public void equals() {
+        // Differ by spaces -> returns true
+        assertEquals(new Author("jk rowling"), new Author("j k rowling"));
+        // Differ by case -> returns true
+        assertEquals(new Author("j K Rowling"), new Author("j k rowling"));
+        // Differ by punctuation -> returns false
+        assertNotEquals(new Author("J. K. Rowling"), new Author("J K Rowling"));
+    }
+
+    @Test
+    public void hashCodeTest() {
+        // Differ by spaces -> returns true
+        assertEquals(new Author("jk rowling").hashCode(), new Author("j k rowling").hashCode());
+        // Differ by case -> returns true
+        assertEquals(new Author("j K Rowling").hashCode(), new Author("j k rowling").hashCode());
+        // Differ by punctuation -> returns false
+        assertNotEquals(new Author("J. K. Rowling").hashCode(), new Author("J K Rowling").hashCode());
+
+        // Testing equality on HashSet
+        HashSet<Author> set1 = new HashSet<>();
+        set1.add(new Author("jk rowling"));
+        HashSet<Author> set2 = new HashSet<>();
+        set2.add(new Author("j k rowling"));
+        assertEquals(set1, set2);
+
+        // Testing equality on lists
+        ArrayList<Author> list1 = new ArrayList<>();
+        list1.add(new Author("jk rowling"));
+        list1.add(new Author("suzanne collins"));
+        ArrayList<Author> list2 = new ArrayList<>();
+        list2.add(new Author("j k rowling"));
+        list2.add(new Author("Suzanne Collins"));
+        assertEquals(list1, list2);
+        assertEquals(list1.hashCode(), list2.hashCode());
     }
 }

--- a/src/test/java/seedu/address/model/book/BookListTest.java
+++ b/src/test/java/seedu/address/model/book/BookListTest.java
@@ -8,6 +8,7 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_BOOK_NAME_HUNGE
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ISBN_HUNGER_GAMES;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_RETURN_DATE;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_SCIFI;
+import static seedu.address.model.util.SampleDataUtil.getSampleBorrowedStatus;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalBooks.AI;
 import static seedu.address.testutil.TypicalBooks.HARRY_POTTER;
@@ -103,6 +104,21 @@ public class BookListTest {
         BookList expectedBookList = new BookList();
         expectedBookList.add(HUNGER_GAMES);
         assertEquals(expectedBookList, bookList);
+    }
+
+    @Test
+    public void hasSameIsbn_noSameIsbn_returnsFalse() {
+        bookList.add(HARRY_POTTER);
+        assertFalse(bookList.hasSameIsbn(HUNGER_GAMES));
+    }
+
+    @Test
+    public void hasSameIsbn_hasSameIsbn_returnsTrue() {
+        bookList.add(HARRY_POTTER);
+        Book allFieldsDifferentExceptIsbn = new BookBuilder(HARRY_POTTER).withName(VALID_BOOK_NAME_HUNGER_GAMES)
+                .withTags().withAuthors().withRequesters(ALICE).withBookStatus(getSampleBorrowedStatus())
+                .withTimeAdded(12345).build();
+        assertTrue(bookList.hasSameIsbn(allFieldsDifferentExceptIsbn));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/book/BookListTest.java
+++ b/src/test/java/seedu/address/model/book/BookListTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_AUTHOR_SUZANNE_COLLINS;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_BOOK_NAME_HUNGER_GAMES;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ISBN_HUNGER_GAMES;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_RETURN_DATE;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_SCIFI;
 import static seedu.address.testutil.Assert.assertThrows;
@@ -113,6 +114,23 @@ public class BookListTest {
         expectedBookList.add(new Book(AI, BookStatus.createAvailableBookStatus()));
         bookList.returnAllBorrowedBooks(getTypicalPatrons().get(0));
         assertEquals(expectedBookList, bookList);
+    }
+
+    @Test
+    public void hasSameIsbnDiffAuthorsOrName() {
+        bookList.add(HARRY_POTTER);
+
+        // same isbn but different name -> returns true
+        Book book2 = new BookBuilder(HARRY_POTTER).withName("diff name").build();
+        assertTrue(bookList.hasSameIsbnDiffAuthorsOrName(book2));
+
+        // same isbn but different authors -> returns true
+        book2 = new BookBuilder(HARRY_POTTER).withAuthors("some author").build();
+        assertTrue(bookList.hasSameIsbnDiffAuthorsOrName(book2));
+
+        // different isbn, but same authors and book name is allowed -> returns false
+        book2 = new BookBuilder(HARRY_POTTER).withIsbn(VALID_ISBN_HUNGER_GAMES).build();
+        assertFalse(bookList.hasSameIsbnDiffAuthorsOrName(book2));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/book/BookNameTest.java
+++ b/src/test/java/seedu/address/model/book/BookNameTest.java
@@ -1,8 +1,13 @@
 package seedu.address.model.book;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
+
+import java.util.ArrayList;
+import java.util.HashSet;
 
 import org.junit.jupiter.api.Test;
 
@@ -43,6 +48,43 @@ public class BookNameTest {
         assertTrue(BookName.isValidBookName("Harry Potter 2")); // alphanumeric characters
         assertTrue(BookName.isValidBookName("Harry Potter 1 The Philosopher's Stone")); // with ' character
         assertTrue(BookName.isValidBookName("Algorithms: 1st Edition")); // with : character
+    }
+
+    @Test
+    public void equals() {
+        // Differ by spaces -> returns true
+        assertEquals(new BookName("harrypotter"), new BookName("harry potter"));
+        // Differ by case -> returns true
+        assertEquals(new BookName("harry potter"), new BookName("Harry Potter"));
+        // Differ by punctuation -> returns false
+        assertNotEquals(new BookName("harry:potter"), new BookName("harry potter"));
+    }
+
+    @Test
+    public void hashCodeTest() {
+        // Differ by spaces -> returns true
+        assertEquals(new BookName("harrypotter").hashCode(), new BookName("harry potter").hashCode());
+        // Differ by case -> returns true
+        assertEquals(new BookName("harry potter").hashCode(), new BookName("Harry Potter").hashCode());
+        // Differ by punctuation -> returns false
+        assertNotEquals(new BookName("harry:potter").hashCode(), new BookName("harry potter").hashCode());
+
+        // Testing equality on HashSet
+        HashSet<BookName> set1 = new HashSet<>();
+        set1.add(new BookName("harrypotter"));
+        HashSet<BookName> set2 = new HashSet<>();
+        set2.add(new BookName("Harry Potter"));
+        assertEquals(set1, set2);
+
+        // Testing equality on lists
+        ArrayList<BookName> list1 = new ArrayList<>();
+        list1.add(new BookName("harrypotter"));
+        list1.add(new BookName("hunger games"));
+        ArrayList<BookName> list2 = new ArrayList<>();
+        list2.add(new BookName("harry potter"));
+        list2.add(new BookName("Hunger Games"));
+        assertEquals(list1, list2);
+        assertEquals(list1.hashCode(), list2.hashCode());
     }
 }
 

--- a/src/test/java/seedu/address/model/book/BookTest.java
+++ b/src/test/java/seedu/address/model/book/BookTest.java
@@ -23,6 +23,7 @@ import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.model.patron.Patron;
 import seedu.address.model.tag.Tag;
 import seedu.address.testutil.BookBuilder;
 
@@ -33,41 +34,48 @@ public class BookTest {
     private static final List<Author> VALID_AUTHORS = new ArrayList<>();
     private static final Set<Tag> VALID_TAGS = new HashSet<>();
     private static final BookStatus VALID_BORROWED_STATUS = getSampleBorrowedStatus();
+    private static final Set<Patron> VALID_REQUESTERS = new HashSet<>();
 
     @Test
     public void constructor_nullBookName_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> new Book(null, VALID_ISBN, VALID_AUTHORS, VALID_TAGS,
-                SAMPLE_BOOK_CREATED_TIME, VALID_AVAILABLE_STATUS));
+                SAMPLE_BOOK_CREATED_TIME, VALID_AVAILABLE_STATUS, VALID_REQUESTERS));
     }
 
     @Test
     public void constructor_nullIsbn_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> new Book(VALID_BOOK_NAME, null, VALID_AUTHORS, VALID_TAGS,
-                SAMPLE_BOOK_CREATED_TIME, VALID_AVAILABLE_STATUS));
+                SAMPLE_BOOK_CREATED_TIME, VALID_AVAILABLE_STATUS, VALID_REQUESTERS));
     }
 
     @Test
     public void constructor_nullAuthors_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> new Book(VALID_BOOK_NAME, VALID_ISBN, null, VALID_TAGS,
-                SAMPLE_BOOK_CREATED_TIME, VALID_AVAILABLE_STATUS));
+                SAMPLE_BOOK_CREATED_TIME, VALID_AVAILABLE_STATUS, VALID_REQUESTERS));
     }
 
     @Test
     public void constructor_nullTags_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> new Book(VALID_BOOK_NAME, VALID_ISBN, VALID_AUTHORS, null,
-                SAMPLE_BOOK_CREATED_TIME, VALID_AVAILABLE_STATUS));
+                SAMPLE_BOOK_CREATED_TIME, VALID_AVAILABLE_STATUS, VALID_REQUESTERS));
     }
 
     @Test
     public void constructor_nullBookStatus_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> new Book(VALID_BOOK_NAME, VALID_ISBN, VALID_AUTHORS, VALID_TAGS,
-                SAMPLE_BOOK_CREATED_TIME, null));
+                SAMPLE_BOOK_CREATED_TIME, null, VALID_REQUESTERS));
+    }
+
+    @Test
+    public void constructor_nullRequesters_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new Book(VALID_BOOK_NAME, VALID_ISBN, VALID_AUTHORS, VALID_TAGS,
+                SAMPLE_BOOK_CREATED_TIME, VALID_AVAILABLE_STATUS, null));
     }
 
     @Test
     public void constructor_copyFromOriginalBook_changesBookStatus() {
         Book originalBook = new Book(VALID_BOOK_NAME, VALID_ISBN, VALID_AUTHORS, VALID_TAGS,
-                SAMPLE_BOOK_CREATED_TIME, VALID_AVAILABLE_STATUS);
+                SAMPLE_BOOK_CREATED_TIME, VALID_AVAILABLE_STATUS, VALID_REQUESTERS);
         Book newBook = new Book(originalBook, VALID_BORROWED_STATUS);
         Book expectedBook = new BookBuilder(originalBook).withBookStatus(VALID_BORROWED_STATUS).build();
         assertEquals(newBook, expectedBook);
@@ -77,6 +85,8 @@ public class BookTest {
     public void asObservableList_modifyList_throwsUnsupportedOperationException() {
         Book book = new BookBuilder().build();
         assertThrows(UnsupportedOperationException.class, () -> book.getTags().remove(0));
+        assertThrows(UnsupportedOperationException.class, () -> book.getAuthors().remove(0));
+        assertThrows(UnsupportedOperationException.class, () -> book.getRequesters().remove(0));
     }
 
     @Test
@@ -156,14 +166,29 @@ public class BookTest {
 
         // Book available -> returns true
         assertTrue(() -> new Book(VALID_BOOK_NAME, VALID_ISBN, VALID_AUTHORS, VALID_TAGS, SAMPLE_BOOK_CREATED_TIME,
-                VALID_AVAILABLE_STATUS).isAvailable());
+                VALID_AVAILABLE_STATUS, VALID_REQUESTERS).isAvailable());
     }
 
     @Test
     public void isBooKAvailable_bookBorrowed_returnsFalse() {
         // book borrowed -> return false
         assertFalse(() -> new Book(VALID_BOOK_NAME, VALID_ISBN, VALID_AUTHORS, VALID_TAGS, SAMPLE_BOOK_CREATED_TIME,
-                VALID_BORROWED_STATUS).isAvailable());
+                VALID_BORROWED_STATUS, VALID_REQUESTERS).isAvailable());
+    }
+
+    @Test
+    public void hasSameAuthors() {
+        // same authors but with spacing, letter case, and ordering difference -> returns true
+        Book book1 = new BookBuilder(HARRY_POTTER).withAuthors("author 1", "author 2").build();
+        Book book2 = new BookBuilder(HARRY_POTTER).withAuthors("Author2", "Author1").build();
+        assertTrue(book1.equals(book2));
+    }
+
+    @Test
+    public void hasSameIsbn() {
+        // same isbn but different hyphen positions -> returns true
+        Book editedHarryPotter = new BookBuilder(HARRY_POTTER).withIsbn(VALID_ISBN_HARRY_POTTER_2).build();
+        assertTrue(HARRY_POTTER.equals(editedHarryPotter));
     }
 
 }

--- a/src/test/java/seedu/address/model/book/BookTest.java
+++ b/src/test/java/seedu/address/model/book/BookTest.java
@@ -14,6 +14,7 @@ import static seedu.address.model.util.SampleDataUtil.SAMPLE_BOOK_CREATED_TIME;
 import static seedu.address.model.util.SampleDataUtil.getSampleBorrowedStatus;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalBooks.HARRY_POTTER;
+import static seedu.address.testutil.TypicalBooks.HUNGER_GAMES;
 import static seedu.address.testutil.TypicalBooks.SEMAPHORE;
 
 import java.util.ArrayList;
@@ -189,6 +190,18 @@ public class BookTest {
         // same isbn but different hyphen positions -> returns true
         Book editedHarryPotter = new BookBuilder(HARRY_POTTER).withIsbn(VALID_ISBN_HARRY_POTTER_2).build();
         assertTrue(HARRY_POTTER.equals(editedHarryPotter));
+    }
+
+    @Test
+    public void getConsistentReplacement_nullEditedBook_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> HARRY_POTTER.getConsistentReplacement(null));
+    }
+
+    @Test
+    public void getConsistentReplacement_differentIsbnNameAuthors_replacesAllThreeFields() {
+        Book expectedBook = new BookBuilder(HARRY_POTTER).withIsbn(VALID_ISBN_HUNGER_GAMES)
+                .withName(VALID_BOOK_NAME_HUNGER_GAMES).withAuthors(VALID_AUTHOR_SUZANNE_COLLINS).build();
+        assertEquals(HARRY_POTTER.getConsistentReplacement(HUNGER_GAMES), expectedBook);
     }
 
 }

--- a/src/test/java/seedu/address/model/book/BookTest.java
+++ b/src/test/java/seedu/address/model/book/BookTest.java
@@ -139,6 +139,16 @@ public class BookTest {
         // different status -> returns false
         editedHarryPotter = new BookBuilder(HARRY_POTTER).withBookStatus(getSampleBorrowedStatus()).build();
         assertFalse(HARRY_POTTER.equals(editedHarryPotter));
+
+        // same authors but with spacing, letter case, and ordering difference -> returns true
+        Book book1 = new BookBuilder(HARRY_POTTER).withAuthors("author 1", "author 2").build();
+        Book book2 = new BookBuilder(HARRY_POTTER).withAuthors("Author2", "Author1").build();
+        assertTrue(book1.equals(book2));
+
+        // same book name but with spacing and letter case difference -> returns true
+        book1 = new BookBuilder(HARRY_POTTER).withName("harry potter").build();
+        book2 = new BookBuilder(HARRY_POTTER).withName("HarryPotter").build();
+        assertTrue(book1.equals(book2));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/book/IsbnTest.java
+++ b/src/test/java/seedu/address/model/book/IsbnTest.java
@@ -1,8 +1,13 @@
 package seedu.address.model.book;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
+
+import java.util.ArrayList;
+import java.util.HashSet;
 
 import org.junit.jupiter.api.Test;
 
@@ -44,5 +49,31 @@ public class IsbnTest {
         assertTrue(Isbn.isValidIsbn("17-18-13730-3")); // ISBN10 with hyphen
         assertTrue(Isbn.isValidIsbn("1718137303")); // ISBN10 without hyphen
         assertTrue(Isbn.isValidIsbn("97-971617-018-8-4")); // ISBN13 starting with 979
+    }
+
+    @Test
+    public void equals() {
+        // Differ hyphen arrangements -> returns true
+        assertEquals(new Isbn("978-71617-018-8-5"), new Isbn("9-7-8-71617-018-8-5"));
+        // Differ strings after hyphen removal -> returns false
+        assertNotEquals(new Isbn("978-71617-018-8-5"), new Isbn("17-18-13730-3"));
+    }
+
+    @Test
+    public void hashCodeTest() {
+        // Differ hyphen arrangements -> returns true
+        assertEquals(new Isbn("978-71617-018-8-5").hashCode(), new Isbn("9-7-8-71617-018-8-5").hashCode());
+        // Differ strings after hyphen removal -> returns false
+        assertNotEquals(new Isbn("978-71617-018-8-5").hashCode(), new Isbn("17-18-13730-3").hashCode());
+
+        // Testing equality on HashSet
+        HashSet<Isbn> set1 = new HashSet<>();
+        set1.add(new Isbn("978-71617-018-8-5"));
+        HashSet<Isbn> set2 = new HashSet<>();
+        set2.add(new Isbn("9-7-8-71617-018-8-5"));
+        assertEquals(set1, set2);
+        HashSet<Isbn> set3 = new HashSet<>();
+        set1.add(new Isbn("17-18-13730-3"));
+        assertNotEquals(set1, set3);
     }
 }

--- a/src/test/java/seedu/address/model/book/IsbnTest.java
+++ b/src/test/java/seedu/address/model/book/IsbnTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 
-import java.util.ArrayList;
 import java.util.HashSet;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/seedu/address/storage/JsonAdaptedBookTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedBookTest.java
@@ -6,6 +6,7 @@ import static seedu.address.model.util.SampleDataUtil.SAMPLE_BOOK_CREATED_TIME;
 import static seedu.address.storage.JsonAdaptedBook.MISSING_FIELD_MESSAGE_FORMAT;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalBooks.ALGORITHM;
+import static seedu.address.testutil.TypicalPatrons.BENSON;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -25,6 +26,7 @@ public class JsonAdaptedBookTest {
     private static final String INVALID_TAG = "#Adventure";
     private static final String INVALID_AUTHOR = "J!KRowling";
     private static final String INVALID_TIME_ADDED = "askdj";
+    private static final String INVALID_REQUESTER_NAME = "R@chel";
 
     private static final String VALID_BOOK_NAME = ALGORITHM.getBookName().fullBookName;
     private static final String VALID_ISBN = ALGORITHM.getIsbn().toString();
@@ -37,6 +39,15 @@ public class JsonAdaptedBookTest {
     private static final String SAMPLE_CREATED_TIME = Long.toString(SAMPLE_BOOK_CREATED_TIME);
     private static final JsonAdaptedBookStatus SAMPLE_AVAILABLE_BOOK_STATUS =
             new JsonAdaptedBookStatus(SAMPLE_AVAILABLE_STATUS);
+    private static final List<JsonAdaptedPatron> VALID_REQUESTERS = ALGORITHM.getRequesters().stream()
+            .map(JsonAdaptedPatron::new)
+            .collect(Collectors.toList());
+    private static final String VALID_REQUESTER_PHONE = BENSON.getPhone().toString();
+    private static final String VALID_REQUESTER_EMAIL = BENSON.getEmail().toString();
+    private static final String VALID_REQUESTER_ID = BENSON.getId().toString();
+    private static final List<JsonAdaptedTag> VALID_REQUESTER_TAGS = BENSON.getTags().stream()
+            .map(JsonAdaptedTag::new)
+            .collect(Collectors.toList());
 
     @Test
     public void toModelType_validBookDetails_returnsBook() throws Exception {
@@ -48,7 +59,7 @@ public class JsonAdaptedBookTest {
     public void toModelType_invalidBookName_throwsIllegalValueException() {
         JsonAdaptedBook book =
                 new JsonAdaptedBook(INVALID_BOOK_NAME, VALID_ISBN, VALID_TAGS, VALID_AUTHORS, SAMPLE_CREATED_TIME,
-                        SAMPLE_AVAILABLE_BOOK_STATUS);
+                        SAMPLE_AVAILABLE_BOOK_STATUS, VALID_REQUESTERS);
         String expectedMessage = BookName.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, book::toModelType);
     }
@@ -56,7 +67,7 @@ public class JsonAdaptedBookTest {
     @Test
     public void toModelType_nullBookName_throwsIllegalValueException() {
         JsonAdaptedBook book = new JsonAdaptedBook(null, VALID_ISBN, VALID_TAGS, VALID_AUTHORS,
-                SAMPLE_CREATED_TIME, SAMPLE_AVAILABLE_BOOK_STATUS);
+                SAMPLE_CREATED_TIME, SAMPLE_AVAILABLE_BOOK_STATUS, VALID_REQUESTERS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, BookName.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, book::toModelType);
     }
@@ -65,7 +76,7 @@ public class JsonAdaptedBookTest {
     public void toModelType_invalidIsbn_throwsIllegalValueException() {
         JsonAdaptedBook book =
                 new JsonAdaptedBook(VALID_BOOK_NAME, INVALID_ISBN, VALID_TAGS, VALID_AUTHORS, SAMPLE_CREATED_TIME,
-                        SAMPLE_AVAILABLE_BOOK_STATUS);
+                        SAMPLE_AVAILABLE_BOOK_STATUS, VALID_REQUESTERS);
         String expectedMessage = Isbn.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, book::toModelType);
     }
@@ -73,9 +84,20 @@ public class JsonAdaptedBookTest {
     @Test
     public void toModelType_nullIsbn_throwsIllegalValueException() {
         JsonAdaptedBook book = new JsonAdaptedBook(VALID_BOOK_NAME, null, VALID_TAGS, VALID_AUTHORS,
-                SAMPLE_CREATED_TIME, SAMPLE_AVAILABLE_BOOK_STATUS);
+                SAMPLE_CREATED_TIME, SAMPLE_AVAILABLE_BOOK_STATUS, VALID_REQUESTERS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Isbn.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, book::toModelType);
+    }
+
+    @Test
+    public void toModelType_invalidRequesters_throwsIllegalValueException() {
+        List<JsonAdaptedPatron> invalidRequesters = new ArrayList<>(VALID_REQUESTERS);
+        invalidRequesters.add(new JsonAdaptedPatron(INVALID_REQUESTER_NAME, VALID_REQUESTER_PHONE,
+                VALID_REQUESTER_EMAIL, VALID_REQUESTER_ID, VALID_REQUESTER_TAGS));
+        JsonAdaptedBook book =
+                new JsonAdaptedBook(VALID_BOOK_NAME, VALID_ISBN, VALID_TAGS, VALID_AUTHORS, SAMPLE_CREATED_TIME,
+                        SAMPLE_AVAILABLE_BOOK_STATUS, invalidRequesters);
+        assertThrows(IllegalValueException.class, book::toModelType);
     }
 
     @Test
@@ -84,7 +106,7 @@ public class JsonAdaptedBookTest {
         invalidTags.add(new JsonAdaptedTag(INVALID_TAG));
         JsonAdaptedBook book =
                 new JsonAdaptedBook(VALID_BOOK_NAME, VALID_ISBN, invalidTags, VALID_AUTHORS, SAMPLE_CREATED_TIME,
-                        SAMPLE_AVAILABLE_BOOK_STATUS);
+                        SAMPLE_AVAILABLE_BOOK_STATUS, VALID_REQUESTERS);
         assertThrows(IllegalValueException.class, book::toModelType);
     }
 
@@ -94,7 +116,7 @@ public class JsonAdaptedBookTest {
         invalidAuthors.add(new JsonAdaptedAuthor(INVALID_AUTHOR));
         JsonAdaptedBook book =
                 new JsonAdaptedBook(VALID_BOOK_NAME, VALID_ISBN, VALID_TAGS, invalidAuthors, SAMPLE_CREATED_TIME,
-                        SAMPLE_AVAILABLE_BOOK_STATUS);
+                        SAMPLE_AVAILABLE_BOOK_STATUS, VALID_REQUESTERS);
         assertThrows(IllegalValueException.class, book::toModelType);
     }
 
@@ -102,7 +124,7 @@ public class JsonAdaptedBookTest {
     public void toModelType_invalidTimeAdded_throwsIllegalValueException() {
         JsonAdaptedBook book =
                 new JsonAdaptedBook(VALID_BOOK_NAME, VALID_ISBN, VALID_TAGS, VALID_AUTHORS, INVALID_TIME_ADDED,
-                        SAMPLE_AVAILABLE_BOOK_STATUS);
+                        SAMPLE_AVAILABLE_BOOK_STATUS, VALID_REQUESTERS);
         String expectedMessage = Book.TIME_ADDED_MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, book::toModelType);
     }
@@ -110,7 +132,7 @@ public class JsonAdaptedBookTest {
     @Test
     public void toModelType_nullBookStatus_throwsIllegalValueException() {
         JsonAdaptedBook book = new JsonAdaptedBook(VALID_BOOK_NAME, VALID_ISBN, VALID_TAGS, VALID_AUTHORS,
-                SAMPLE_CREATED_TIME, null);
+                SAMPLE_CREATED_TIME, null, VALID_REQUESTERS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, BookStatus.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, book::toModelType);
     }

--- a/src/test/java/seedu/address/storage/JsonAdaptedPatronTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPatronTest.java
@@ -20,7 +20,7 @@ import seedu.address.model.patron.Phone;
 public class JsonAdaptedPatronTest {
     private static final String INVALID_NAME = "R@chel";
     private static final String INVALID_PHONE = "+651234";
-    private static final String INVALID_ADDRESS = " ";
+    private static final String INVALID_ID = " ";
     private static final String INVALID_EMAIL = "example.com";
     private static final String INVALID_TAG = "#friend";
 
@@ -86,7 +86,7 @@ public class JsonAdaptedPatronTest {
     @Test
     public void toModelType_invalidAddress_throwsIllegalValueException() {
         JsonAdaptedPatron patron =
-                new JsonAdaptedPatron(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_ADDRESS, VALID_TAGS);
+                new JsonAdaptedPatron(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_ID, VALID_TAGS);
         String expectedMessage = Id.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, patron::toModelType);
     }

--- a/src/test/java/seedu/address/testutil/BookBuilder.java
+++ b/src/test/java/seedu/address/testutil/BookBuilder.java
@@ -13,6 +13,7 @@ import seedu.address.model.book.Book;
 import seedu.address.model.book.BookName;
 import seedu.address.model.book.BookStatus;
 import seedu.address.model.book.Isbn;
+import seedu.address.model.patron.Patron;
 import seedu.address.model.tag.Tag;
 import seedu.address.model.util.SampleDataUtil;
 
@@ -32,6 +33,7 @@ public class BookBuilder {
     private Set<Tag> tags;
     private long timeAdded;
     private BookStatus bookStatus;
+    private Set<Patron> requesters;
 
     /**
      * Creates a {@code BookBuilder} with the default details.
@@ -43,6 +45,7 @@ public class BookBuilder {
         tags = new HashSet<Tag>();
         timeAdded = DEFAULT_TIME_ADDED;
         bookStatus = DEFAULT_BOOK_STATUS;
+        requesters = new HashSet<Patron>();
     }
 
     /**
@@ -55,6 +58,7 @@ public class BookBuilder {
         tags = new HashSet<Tag>(bookToCopy.getTags());
         timeAdded = bookToCopy.getTimeAdded();
         bookStatus = bookToCopy.getBookStatus();
+        requesters = bookToCopy.getRequesters();
     }
 
     /**
@@ -105,7 +109,15 @@ public class BookBuilder {
         return this;
     }
 
+    /**
+     * Parses the {@code requesters} into a {@code Set<Patron>} and set it to the {@code Book} that we are building.
+     */
+    public BookBuilder withRequesters(Patron ... requesters) {
+        this.requesters = SampleDataUtil.getRequesterSet(requesters);
+        return this;
+    }
+
     public Book build() {
-        return new Book(bookName, isbn, authors, tags, timeAdded, bookStatus);
+        return new Book(bookName, isbn, authors, tags, timeAdded, bookStatus, requesters);
     }
 }


### PR DESCRIPTION
Fix data integrity issues in the following areas:

1. **Delete Book**
   1. Books that are under borrow cannot be deleted
2. **Edit Book**
   1. Book A cannot have its isbn changed from ISBN A to ISBN B if ISBN B is already present in LibTask. This is so that there will not be different set of requesters requesting for ISBN B (e.g. requesters originally requesting for ISBN A will be wrongly treated as requesting for ISBN B if change in isbn is allowed).
   2. Whenever a book is edited, all books with the same isbn will also be edited to have their authors and book names updated. This is to ensure data consistency whereby no two books can have same isbn but have different set of authors or book name. They can however, differ in tags, because tag may refer to location tags (e.g. science library or central library).
3. **Add Book**
   1. Adding books with same isbn as existing books is allowed, but only if the author set and book name is equivalent (ignoring spacings, author order and letter case) to the existing book with same isbn.
   2. If there are existing requests for the newly added book, adding the book will remove all requests, and the librarian will be prompted to notify the requesters about the availability of the newly added book.
4. **Return Book**
   1. Upon returning of book/books, all existing requests related to those books will be removed, and the librarian will be prompted to notify the requesters about the availability of the returned book/books.
